### PR TITLE
[#17] Crash upon loading/saving unregistered foods.

### DIFF
--- a/src/main/java/com/cazsius/solcarrot/capability/FoodCapability.java
+++ b/src/main/java/com/cazsius/solcarrot/capability/FoodCapability.java
@@ -47,7 +47,9 @@ public class FoodCapability implements ICapabilitySerializable<NBTBase> {
 		NBTTagList list = new NBTTagList();
 		for (FoodInstance fInstance : this.foodList) 
 		{
-			String toWrite = ((ResourceLocation) Item.REGISTRY.getNameForObject(fInstance.item())).toString();
+			ResourceLocation location = Item.REGISTRY.getNameForObject(fInstance.item());
+			if (location == null) break;
+			String toWrite = location.toString();
 			toWrite+="@"+fInstance.meta();
 			list.appendTag(new NBTTagString(toWrite));
 		}
@@ -61,8 +63,10 @@ public class FoodCapability implements ICapabilitySerializable<NBTBase> {
 		for (int i = 0; i < list.tagCount(); i++)
 		{
 			String toDecompose = ((NBTTagString) list.get(i)).getString();
-			String name = toDecompose.substring(0, toDecompose.indexOf("@"));
-			int meta = Integer.decode(toDecompose.substring(toDecompose.indexOf("@")+1)); 
+			int index = toDecompose.indexOf("@");
+			if (index < 0) break;
+			String name = toDecompose.substring(0, index);
+			int meta = Integer.decode(toDecompose.substring(index + 1)); 
 			this.addFood(Item.getByNameOrId(name), meta);
 		}
 	}

--- a/src/main/java/com/cazsius/solcarrot/capability/FoodCapability.java
+++ b/src/main/java/com/cazsius/solcarrot/capability/FoodCapability.java
@@ -48,7 +48,7 @@ public class FoodCapability implements ICapabilitySerializable<NBTBase> {
 		for (FoodInstance fInstance : this.foodList) 
 		{
 			ResourceLocation location = Item.REGISTRY.getNameForObject(fInstance.item());
-			if (location == null) break;
+			if (location == null) continue;
 			String toWrite = location.toString();
 			toWrite+="@"+fInstance.meta();
 			list.appendTag(new NBTTagString(toWrite));
@@ -64,7 +64,7 @@ public class FoodCapability implements ICapabilitySerializable<NBTBase> {
 		{
 			String toDecompose = ((NBTTagString) list.get(i)).getString();
 			int index = toDecompose.indexOf("@");
-			if (index < 0) break;
+			if (index < 0) continue;
 			String name = toDecompose.substring(0, index);
 			int meta = Integer.decode(toDecompose.substring(index + 1)); 
 			this.addFood(Item.getByNameOrId(name), meta);


### PR DESCRIPTION
Tiny fix to issue #17, which would occur e.g. when mods whose foods you've eaten were removed or their item IDs changed. (This happened to me after updating a pack, so I was able to verify that this fix works.)

Because it just skips over unregistered items, those items would effectively be removed. Debatably, the items should instead still be kept as placeholders, e.g. in case you put the mod back in. This would also raise the question of whether or not the placeholder items still count for hearts.