### PR TITLE
Check if eaten food still exists

### DIFF
--- a/src/main/java/com/cazsius/solcarrot/capability/FoodCapability.java
+++ b/src/main/java/com/cazsius/solcarrot/capability/FoodCapability.java
@@ -65,8 +65,12 @@ public class FoodCapability implements ICapabilitySerializable<NBTBase> {
 			int index = toDecompose.indexOf("@");
 			if (index < 0) continue;
 			String name = toDecompose.substring(0, index);
-			int meta = Integer.decode(toDecompose.substring(index + 1)); 
-			this.addFood(Item.getByNameOrId(name), meta);
+			int meta = Integer.decode(toDecompose.substring(index + 1));
+			Item item = Item.getByNameOrId(name);
+			if (item != null)
+			{
+				this.addFood(item, meta);
+			}
 		}
 	}
 


### PR DESCRIPTION
After a recent Modern Skyblock 3 update, players were unable to join our server because of a NPE with Spice of Life:
```
net.minecraft.util.ReportedException: Loading entity NBT
        at net.minecraft.entity.Entity.func_70020_e(Entity.java:1875) ~[vg.class:?]
        at net.minecraft.world.storage.SaveHandler.func_75752_b(SaveHandler.java:224) ~[bfb.class:?]
        at net.minecraft.server.management.PlayerList.func_72380_a(PlayerList.java:323) ~[pl.class:?]
        at net.minecraft.server.management.PlayerList.initializeConnectionToPlayer(PlayerList.java:1477) ~[pl.class:?]
        at shadows.fastbench.net.HijackedDedicatedPlayerList.initializeConnectionToPlayer(HijackedDedicatedPlayerList.java:19) ~[HijackedDedicatedPlayerList.class:?]
        at net.minecraftforge.fml.common.network.handshake.NetworkDispatcher.completeServerSideConnection(NetworkDispatcher.java:256) ~[NetworkDispatcher.class:?]
        at net.minecraftforge.fml.common.network.handshake.NetworkDispatcher.access$100(NetworkDispatcher.java:72) ~[NetworkDispatcher.class:?]
        at net.minecraftforge.fml.common.network.handshake.NetworkDispatcher$1.func_73660_a(NetworkDispatcher.java:205) ~[NetworkDispatcher$1.class:?]
        at net.minecraft.network.NetworkManager.func_74428_b(NetworkManager.java:285) ~[gw.class:?]
        at net.minecraft.network.NetworkSystem.func_151269_c(NetworkSystem.java:180) [oz.class:?]
        at net.minecraft.server.MinecraftServer.func_71190_q(MinecraftServer.java:788) [MinecraftServer.class:?]
        at net.minecraft.server.dedicated.DedicatedServer.func_71190_q(DedicatedServer.java:396) [nz.class:?]
        at net.minecraft.server.MinecraftServer.func_71217_p(MinecraftServer.java:666) [MinecraftServer.class:?]
        at net.minecraft.server.MinecraftServer.run(MinecraftServer.java:524) [MinecraftServer.class:?]
        at java.lang.Thread.run(Thread.java:748) [?:1.8.0_144]
Caused by: java.lang.NullPointerException
        at com.cazsius.solcarrot.capability.FoodInstance.equals(FoodInstance.java:47) ~[FoodInstance.class:?]
        at java.util.HashMap.putVal(HashMap.java:634) ~[?:1.8.0_144]
        at java.util.HashMap.put(HashMap.java:611) ~[?:1.8.0_144]
        at java.util.HashSet.add(HashSet.java:219) ~[?:1.8.0_144]
        at com.cazsius.solcarrot.capability.FoodCapability.addFood(FoodCapability.java:26) ~[FoodCapability.class:?]
        at com.cazsius.solcarrot.capability.FoodCapability.deserializeNBT(FoodCapability.java:69) ~[FoodCapability.class:?]
        at net.minecraftforge.common.capabilities.CapabilityDispatcher.deserializeNBT(CapabilityDispatcher.java:135) ~[CapabilityDispatcher.class:?]
        at net.minecraft.entity.Entity.func_70020_e(Entity.java:1849) ~[vg.class:?]
        ... 14 more
```

It seems like the update removed some food items which these players previously ate. This caused a NPE as some items stored by the FoodCapability no longer existed.
This PR adds a null check to prevent this from happening again.