### PR TITLE
Correctly specify dependency

### DIFF
--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -21,7 +21,7 @@ Instead of using the stick, we use the carrot!
 '''
 
 # Dependencies are optional.
-[[dependencies]]
+[[dependencies.solcarrot]]
 	modId = "forge"
 	mandatory = true
 	versionRange = "[36,)"


### PR DESCRIPTION
A mods dependency should be delcared in the format of `dependencies.modId` where `modId` correlates to the id from the preceding `[[mods]]`-map.

This also helps me identify the sideness of the mod, as seen here https://github.com/Griefed/ServerPackCreator/issues/70