### PR TITLE
Correctly specify dependencies

### DIFF
--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -21,14 +21,14 @@ Instead of using the stick, we use the carrot!
 '''
 
 # Dependencies are optional.
-[[dependencies]]
+[[dependencies.solcarrot]]
 	modId = "forge"
 	mandatory = true
 	versionRange = "[28,)"
 	ordering = "NONE" # BEFORE or AFTER required if the relationship is not mandatory
 	side = "BOTH" # BOTH, CLIENT or SERVER
 
-[[dependencies]]
+[[dependencies.solcarrot]]
 	modId = "minecraft"
 	mandatory = true
 	versionRange = "[1.14.4]"


### PR DESCRIPTION
A mods dependency should be delcared in the format of `dependencies.modId` where `modId` correlates to the id from the preceding `[[mods]]`-map.

This also helps me identify the sideness of the mod, as seen here https://github.com/Griefed/ServerPackCreator/issues/70